### PR TITLE
drakma -> dexador, with-open-file ... -> str:to-file

### DIFF
--- a/content/posts/hooks
+++ b/content/posts/hooks
@@ -59,21 +59,18 @@ function just for that!
 #+BEGIN_SRC lisp
 (defun download-web-page-to-notes ()
   (let* ((url (interface:web-view-get-url (view *active-buffer*)))
-         (web-page-contents (drakma:http-request url))
+         (web-page-contents (dex:get url))
          (body-contents
            (lquery:$1
              (initialize web-page-contents) "body" (children) (serialize))))
-    (with-open-file (str "~/Downloads/notes.txt"
-                         :direction :output
-                         :if-exists :supersede
-                         :if-does-not-exist :create)
-      (format str "~s" body-contents))))
+    (str:to-file "~/Downloads/notes.txt" body-contents)))
 #+END_SRC
 
-The above function will load the web page into a string via [[https://edicl.github.io/drakma/][drakma]] (an
+The above function will load the web page into a string via [[http://quickdocs.org/dexador/][dexador]] (an
 http library). After loading the web page into a string, it'll be
 passed to [[https://github.com/Shinmera/lquery][lquery]](a document parsing library). Finally, it will write
-the body of the document to a file. Of course our function could be
+the body  of the document  to a file,  via [[https://github.com/vindarel/cl-str][str]] (a  string manipulation
+library). Of course our function could be
 improved, but this is the most simple version.
 
 ** Hooking in to the bookmark save process

--- a/content/posts/hooks
+++ b/content/posts/hooks
@@ -73,6 +73,8 @@ the body  of the document  to a file,  via [[https://github.com/vindarel/cl-str]
 library). Of course our function could be
 improved, but this is the most simple version.
 
+Don't miss the [[https://lispcookbook.github.io/cl-cookbook/][Common Lisp Cookbook]] if you need a good resource.
+
 ** Hooking in to the bookmark save process
 Now that we've written our super short function, we should be able to
 hook into the =bookmark-current-page= command. This is done like this:


### PR DESCRIPTION
Hello,

"point taken" from reddit ;)

Those are only suggestions.

- http://quickdocs.org/dexador/ is pretty convincing. TBH I never used Drakma, this is just personal preference (I like the shorter verbs)
- however I really don't see why we still need so many lines and details to write a string to a file, so I suggest to use https://github.com/vindarel/cl-str: that's my library, born out of frustration right from the beginning. `str:to-file` takes the same keys as `with-open-file` so it's a drop-in replacement. To *read* from files there is `uiop:read-file-string` and `read-file-lines`, but nothing to write to files it seems. 

Cheers !